### PR TITLE
Rather than calling systemctl, use new function

### DIFF
--- a/pre-scan.pl
+++ b/pre-scan.pl
@@ -156,7 +156,7 @@ my $LVcommand = "lvcreate --snapshot --size=" . $cfg->{"snapshotSize"} . " --nam
 `$LVcommand`;
 if ($? != 0) {   # then the snapshot failed
 	&log  ("Failed to create the snapshot -- check for sufficient (250Mb) space in the '" . $cfg->{"mysqlVolumeGroup"} . "' volume group?");
-	`systemctl start mariadb.service`; # the slave process will autorestart
+	startDatabase();
 	&gone ("Backup failed, but I tried to restart the primary mariadb.service"); # does not return
 }
 $DEBUG && print "Snapshot created: $snapLV...\n";


### PR DESCRIPTION
Resolving #2 .
The library now contains a function for restarting the database.  This revision calls the function, instead of calling systemctl directly.