### PR TITLE
Issue5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ warning: /etc/UAL-Veeam-MariaDB-Export.conf saved as /etc/UAL-Veeam-MariaDB-Expo
 * If you'd like to try running it from cron, consider: 
 
 ```
-[root@mariadb-db-tst-secondary-1 UAL-Veeam-MariaDB-Export]# ln -s pre-scan.pl /usr/local/bin
-[root@mariadb-db-tst-secondary-1 UAL-Veeam-MariaDB-Export]# ln -s post-backup.pl /usr/local/bin
-[root@mariadb-db-tst-secondary-1 UAL-Veeam-MariaDB-Export]# ln -s UALBackups.pm  /usr/local/bin
+cd /usr/local/bin
+ln -s /root/UAL-Veeam-MariaDB-Export/pre-scan.pl .
+ln -s /root/UAL-Veeam-MariaDB-Export/post-backup.pl .
+ln -s /root/UAL-Veeam-MariaDB-Export/UALBackups.pm .
 ```
 
-... but obviously, you'd have to remember to undo that, before attempting to install it from RPM
+... but obviously, you'd have to remember to undo that, before attempting to install it from RPM again!!


### PR DESCRIPTION
Here are the tests I did: 

- I ran pre-scan with DEBUG=1, noted that in the output, it now calls cleanUp() early, before starting the backup.
- (ran post-backup)
- Down in /var/backups/mysql, I found the tarball just created, unpacked a file within it into the tmp dir therein, recreating the problem we're trying to fix
- I ran pre-scan again.  This time, with the fix in place, it deleted the contents of the tmp directory, and made another backup
- I ran post-backup -- all is fine!

I'm declaring this fit for Production!